### PR TITLE
#100: Adjust Advancement Value Calculation on NPC/Character Sheet

### DIFF
--- a/src/module/document/item/skill.js
+++ b/src/module/document/item/skill.js
@@ -33,14 +33,15 @@ export class OQSkill extends OQBaseItem {
       const { formula, advancement, mod } = this.system;
       const finalMod = mod ?? 0;
       const rollData = this.parent.getRollData();
-      const rollFormula = `${formula} + ${advancement}`;
-      const total = new Roll(rollFormula, rollData).roll({ async: false }).total;
+      const baseValue = new Roll(formula, rollData).roll({ async: false }).total;
+      const total = baseValue + advancement;
       const value = minMaxValue(total);
       const valueWithMod = mod && minMaxValue(value + mod);
       const mastered = value >= 100;
 
       return {
         value,
+        baseValue,
         mod: finalMod,
         valueWithMod,
         mastered,

--- a/src/module/sheet/actor/actor-base-sheet.js
+++ b/src/module/sheet/actor/actor-base-sheet.js
@@ -174,8 +174,16 @@ export class OQActorBaseSheet extends ActorSheet {
     const itemContainer = targetElem.closest('.item');
     const item = this.actor.items.get(itemContainer?.dataset?.itemId);
     if (item) {
-      const value = targetElem.value;
-      await item.update({ 'system.advancement': value });
+      const value = parseInt(targetElem.value) ?? 0;
+      if (!isNaN(value)) {
+        if (value < 0) {
+          const rollData = item.getTestRollData();
+          const advancement = -value - (rollData.baseValue ?? 0);
+          await item.update({ 'system.advancement': advancement });
+        } else {
+          await item.update({ 'system.advancement': value });
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This update changes the behavior of the advancement field on the NPC/Character sheet. Now, entering a negative value in the advancement field is interpreted as the desired final value (without the negative sign). The advancement is then calculated based on this final value and the base value.

Closes #100 